### PR TITLE
feat:add support for nixos file system

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use std::{
 const DB_PATHS: &[&str] = &[
     "/usr/share/hwdata/pci.ids",
     "/usr/share/misc/pci.ids",
+    "/run/current-system/sw/share/pci.ids", // NixOS
     "@hwdata@/share/hwdata/pci.ids",
 ];
 #[cfg(feature = "online")]


### PR DESCRIPTION
The nixos distro does not have traditional unix file system (no /usr/share) hence it cannot find the files and gives error e.g. during file read. This adds support for nixos